### PR TITLE
About section correction

### DIFF
--- a/scss/partials/_about-me.scss
+++ b/scss/partials/_about-me.scss
@@ -52,16 +52,8 @@
     grid-column: port / port;
 
     @include mq {
-      grid-column: image-end / port-end;
+      grid-column: img-end / port-end;
     }
-  }
-
-  .about-subtitle {
-    grid-row: 2 / 3;
-  }
-
-  .about-text {
-    grid-row: 3 / 4;
   }
 
 }


### PR DESCRIPTION
You named templete column "img-end", but in video, you wrote image-end, and because of that, you had to write additional code, to compensate that. With this, it should all line properly, one beneath another.