### PR TITLE
Fix to contact form Name and Email width bug in Chrome.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -657,9 +657,9 @@ form {
     @media (min-width: 50em) {
       form {
         display: grid;
-        grid-column: 1fr 1fr;
+        grid-template-columns: 50% 50%;
         grid-column-gap: 1em;
-        grid-template-areas: "name     email" "message message" "   .      button"; }
+        grid-template-areas: "name     email" "message  message" ".        button"; }
         form .name {
           grid-area: name; }
         form .email {

--- a/scss/partials/_contact.scss
+++ b/scss/partials/_contact.scss
@@ -14,12 +14,12 @@ form {
   @supports (display: grid) {
     @include mq {
       display: grid;
-      grid-column: 1fr 1fr; 
+      grid-template-columns: 50% 50%; 
       grid-column-gap: 1em;
       grid-template-areas:
         "name     email"
-        "message message"
-        "   .      button";
+        "message  message"
+        ".        button";
 
         .name {
           grid-area: name;


### PR DESCRIPTION
It seems that, as in your latest video, it's a bug related to Chrome (Firefox is fine) where when re-sizing the browser the Name field seems to reduce in size while the Email field is fine. Seems Chrome doesn't like "1fr 1fr" but works fine with "50% 50%".