### PR TITLE
Scroll problem

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -14,7 +14,7 @@ portfolioContainer.addEventListener('click', e => {
   const modalOpen = _ => {
     modal.classList.add('is-open')
     modal.style.animation = 'modalIn 500ms forwards'
-    document.body.style.overflowY = 'hidden'
+    //document.body.style.overflowY = 'hidden'
   }
 
   const modalClose = _ => {
@@ -25,7 +25,7 @@ portfolioContainer.addEventListener('click', e => {
   closeButton.addEventListener('click', _ => {
     modal.style.animation = 'modalOut 500ms forwards'
     modal.addEventListener('animationend', modalClose)
-    document.body.style.overflowY = 'scroll'
+    //document.body.style.overflowY = 'scroll'
   })
 
   document.addEventListener('keydown', e => {


### PR DESCRIPTION
So, it turns out that if you give a "document.body.style.overflowY = 'scroll'" it overrides the initial overflow="hidden" of a class "nav-is-open", so you can scroll the page, while menu is opened. 

I just commented out this, cause I don't know is there a way around this, so for now, it's better to stay off.